### PR TITLE
converted absolute path to relative path

### DIFF
--- a/protect.sh
+++ b/protect.sh
@@ -1,12 +1,8 @@
 #!/bin/bash
 
-date >> /home/ubuntu/app/protectgrass/history.log
-
-cd /home/ubuntu/app/protectgrass/
-
-/usr/bin/git add . >> /home/ubuntu/app/protectgrass/history.log
-
-/usr/bin/git commit -m "protected grass" >> /home/ubuntu/app/protectgrass/history.log
-
-/usr/bin/git push origin master >> /home/ubuntu/app/protectgrass/history.log
+date >> ~/.protectgrass/history.log
+cd ~/.protectgrass/
+/usr/bin/git add . >> ~/.protectgrass/history.log
+/usr/bin/git commit -m "protected grass" >> ~/.protectgrass/history.log
+/usr/bin/git push origin master >> ~/.protectgrass/history.log
 

--- a/readme.md
+++ b/readme.md
@@ -1,17 +1,14 @@
-깃허브 정원 관리사
-=============
+# 깃허브 정원 관리사
 
 ##### 일 하지 않을 때도 잔디 하나를 심어줍니다
 
+## 개발환경 구축 방법
 
-개발환경 구축 방법
--------------
-
-- <code>mkdir workspace</code>
-- <code>cd workspace</code>
-- <code>git clone https://github.com/sungkuk5420/protectgrass</code>
-- <code>cd protectgrass</code>
-- <code>git remote set-url origin https://<id>:<pw>@github.com/sungkuk5420/protectgrass</code>
-- <code>sudo crontab -e</code>
-- <code>30 00 * * * root /home/ubuntu/app/protectgrass/protect.sh</code>
-
+```{bash}
+git clone https://github.com/sungkuk5420/protectgrass
+mv protectgrass ~/.protectgrass
+cd ~/.protectgrass
+git remote set-url origin https://<id>:<pw>@github.com/sungkuk5420/protectgrass
+sudo crontab -e
+30 00 * * * root ~/.protectgrass/protect.sh
+```


### PR DESCRIPTION
절대경로를 상대경로로 바꿔서 인스트럭션대로 하면 누구나 사용할 수 있게 바꿔보았습니다.
`/usr/bin/git`을 `git` 대신 사용하신 이유는 정확히 모르겠어서 가만히 두었습니다.

I converted the absolute path to the relative path for the other users to use this code without changing the path. I am not sure why you use `/usr/bin/git` instead of using just `git`, so I didn't make any changes for that.